### PR TITLE
Async CB is now required, by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ var api = {
   usage:   valid.sync(usage, 'string|boolean'), // multiple types
   get:     valid.async(get, 'string'),
   add:     valid.async(add, ['string'], ['string', 'object']), // multiple signatures
+  put:     valid.async(add, {cbOptional: true}, 'string'), // async method works without a cb
   list:    valid.source(list, 'queryOpts?') // optional param
 }
 


### PR DESCRIPTION
This (breaking) update now throws `MissingCallback` if an async method is called without a callback parameter.

Async methods that dont require a callback (eg they use `cont`) can set `{cbOptional:true}` in the second param of their spec, like so:

``` js
valid.async(add, {cbOptional: true}, ...)
```
